### PR TITLE
fix: datetime string ":" template parse failed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,8 @@ target
 .git*
 .classpath
 
+## .gitignore for intellij
+*.iml
+*.ipr
+*.iws
+.idea/

--- a/protocol_dubbo/src/main/java/com/tony/test/protocol/MethodRule.java
+++ b/protocol_dubbo/src/main/java/com/tony/test/protocol/MethodRule.java
@@ -39,7 +39,7 @@ public class MethodRule {
         for (int i = 0; i < serviceMethedRules.size(); i++) {
             String when = serviceMethedRules.get(i).getWhenScript();
             String thenMessage = serviceMethedRules.get(i).getReturnMessage();
-            scriptContext.append("if( ").append(when).append(") {").append("print \"").append(removeLine(thenMessage)).append("\";\n return;}\n ");
+            scriptContext.append("if( ").append(when).append(") {").append("print \"\"\"").append(removeLine(thenMessage)).append("\"\"\";\n return;}\n ");
         }
         scriptContext.append("print null;\n");
         scriptContext.append(" %>");


### PR DESCRIPTION
    ```json
    {"id": 1, "gmtStart": "2019-02-18 13:30:29"}
    ```
