### PR TITLE
fix: slf4j multiple_bindings, initSql close connection

### DIFF
--- a/mock_web/src/main/java/com/tony/test/controller/BootStartServer.java
+++ b/mock_web/src/main/java/com/tony/test/controller/BootStartServer.java
@@ -1,6 +1,7 @@
 package com.tony.test.controller;
 
 import java.sql.Connection;
+import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -54,9 +55,11 @@ public class BootStartServer implements InitializingBean, DisposableBean {
 	}
 
 	private void initSql() {
+		Connection conn = null;
+		Statement stmt = null;
 		try {
-			Connection conn = mockDataSource.getConnection();
-			Statement stmt = conn.createStatement();
+			conn = mockDataSource.getConnection();
+			stmt = conn.createStatement();
 
 			List<String> aa = IOUtils.readLines(getClass().getClassLoader().getResourceAsStream("sqlite.sql"));
 			String s = StringUtils.join(aa, "\r\n");
@@ -64,12 +67,26 @@ public class BootStartServer implements InitializingBean, DisposableBean {
 
 			for (int i = 0; i < sqls.length; i++) {
 				String sql = sqls[i];
-				System.out.println("初始化sql : " + sql);
 				stmt.execute(sql);
+				System.out.println("初始化sql : " + sql);
 			}
-			stmt.close();
-			conn.close();
 		} catch (Exception e) {
+			// ignore
+		} finally {
+			if(stmt != null) {
+				try {
+					stmt.close();
+				} catch (SQLException e) {
+					// ignore
+				}
+			}
+			if (conn != null) {
+				try {
+					conn.close();
+				} catch (SQLException e) {
+					// ignore
+				}
+			}
 		}
 	}
 

--- a/pom.xml
+++ b/pom.xml
@@ -260,10 +260,10 @@
 			<groupId>log4j</groupId>
 			<artifactId>log4j</artifactId>
 		</dependency>
-		<dependency>
+		<!--<dependency>
 			<groupId>ch.qos.logback</groupId>
 			<artifactId>logback-classic</artifactId>
-		</dependency>
+		</dependency>-->
 		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-beans</artifactId>


### PR DESCRIPTION
1. use log4j, no need for logback
2. initSql when the tables exist, should close connection